### PR TITLE
Changed ordering of fetched haikus

### DIFF
--- a/haikubot/connectivity/stash.py
+++ b/haikubot/connectivity/stash.py
@@ -16,7 +16,7 @@ def make_urls():
     for project in config.STASH_REPOSITORIES:
         for repo in project['REPOSITORIES']:
             flat_list.append(
-                "{}rest/api/1.0/projects/{}/repos/{}/pull-requests".format(url, project['REPO_KEY'], repo)
+                "{}rest/api/1.0/projects/{}/repos/{}/pull-requests?order=NEWEST&state=ALL".format(url, project['REPO_KEY'], repo)
             )
 
     logging.debug('URLs configured: ' + str(flat_list))
@@ -46,6 +46,7 @@ class Stash(Thread):
                     result = None
                     try:
                         result = self.fetch(url)
+
                         if 'errors' in result:
                             logging.error('Stash responded with error: ' + str(result["errors"]))
                             continue
@@ -77,6 +78,7 @@ class Stash(Thread):
 
     def fetch(self, url):
         response = requests.get(url, headers=config.STASH_HEADERS, verify=config.SSL_VERIFY)
+        
         return json.loads(response.text)
 
     def stop(self):

--- a/haikubot/utils/haiku_parser.py
+++ b/haikubot/utils/haiku_parser.py
@@ -1,11 +1,16 @@
 import logging
 
+def sort_by_created(pullRequest):
+  return pullRequest['createdDate']
 
 def parse_stash_response(response, repo_id, store=None):
     logging.debug('Parsing stash response: ' + str(response))
     parsed_haikus = []
 
-    for val in response['values']:
+    pullRequests = response['values']
+    pullRequests.sort(key=sort_by_created)
+
+    for val in pullRequests:
         if store is not None:
             if store.is_checked('{}{}'.format(repo_id, val['id'])):
                 logging.debug('Response {} has been parsed before, skipping'.format(val['id']))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ colorharmonies
 slackclient
 sqlalchemy
 wordcloud
+websocket

--- a/run_haikubot.py
+++ b/run_haikubot.py
@@ -3,6 +3,7 @@ from haikubot.bot import Haikubot
 
 if __name__ == "__main__":
     bot = Haikubot(config.API_KEY)
+
     try:
         bot.run()
     except Exception as err:


### PR DESCRIPTION
This enables haikubot to notice recent pull-requests and post them in correct order, even after some downtime.
Previously a pull-request that was be created and merged during downtime would go unnoticed.

Also added websocket as a dependency and moved run_haikubot.py to root, feel free ignore the additional changes if you disagree.