### PR TITLE
Introduced timeline stistics to haikubot

### DIFF
--- a/haikubot/commands/commands.py
+++ b/haikubot/commands/commands.py
@@ -13,6 +13,7 @@ class Commands(Enum):
     STATS_LONGEST = 'stats longest'
     STATS_FEWEST = 'stats fewest'
     STATS_MOST = 'stats most'
+    STATS_TIMELINE = 'stats timeline'
     ADD_HAIKU = 'add haiku'
     DELETE_HAIKU = 'delete haiku'
     WORDCLOUD = 'wordcloud'
@@ -42,7 +43,9 @@ class Commands(Enum):
    10. haiku with longest word:      @haikubot stats longest
    11. haiku with fewest words:      @haikubot stats fewest
    12. haiku with most words:        @haikubot stats most
-   13. wordcloud of all haiku:       @haikubot wordcloud
-   14. wordcloud from single author: @haikubot wordcloud <author>
-   15. wordcloud from last 3 weeks:  @haikubot wordcloud sprint
+   13. timeline stats:               @haikubot stats timeline
+   14. timeline stats from sprint:   @haikubot stats timeline sprint
+   15. wordcloud of all haiku:       @haikubot wordcloud
+   16. wordcloud from single author: @haikubot wordcloud <author>
+   17. wordcloud from sprint:        @haikubot wordcloud sprint
 ```"""

--- a/haikubot/connectivity/slack.py
+++ b/haikubot/connectivity/slack.py
@@ -83,10 +83,10 @@ class Slack:
         )
         return result['ok']
 
-    def post_image(self, image, author, channel):
+    def post_image(self, image, filename, channel):
         result = self.sc.api_call(
             'files.upload',
-            filename='Wordcloud for {}, {}.png'.format(author, str(datetime.today())),
+            filename=filename,
             file=image,
             channels=channel,
         )

--- a/haikubot/utils/timeliner.py
+++ b/haikubot/utils/timeliner.py
@@ -1,0 +1,71 @@
+from io import BytesIO
+
+from matplotlib.colors import LinearSegmentedColormap
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+import numpy as np
+
+from haikubot.utils.string_cleaner import clean_characters, clean_words, camel_case_clean
+from haikubot.utils.color import string_to_color_hex
+
+def get_authors(haikus):
+  authors = []
+
+  for haiku in haikus:
+    author = haiku[2]
+
+    if (author not in authors):
+      authors.append(author)
+
+  return authors
+
+def set_legend(ax, line, author, ):
+  leg = Legend(ax, lines[2:], ['line C', 'line D'],
+             loc='lower right', frameon=False)
+  ax.add_artist(leg)
+
+
+def clean_graph(graph):
+    maxVal = np.amax(graph)
+    clean = np.delete(graph, np.argwhere(graph == maxVal))
+
+    return np.append(clean, maxVal)
+
+def plot_author(ax, graph, author, anonymous = True):
+      clean = clean_graph(graph)
+      lastX = len(clean) - 1
+      maxVal = np.amax(graph)
+      
+      ax.plot(clean, color=string_to_color_hex(author) )
+      ax.scatter(lastX, maxVal, color=string_to_color_hex(author))
+      if not anonymous:
+        ax.text(lastX, maxVal, s=author, color=string_to_color_hex(author), ha='right', va='bottom')
+
+
+def generate_timeline(haikus, anonymous = True):
+    authors = get_authors(haikus)
+
+    graphs = np.zeros((len(haikus), len(authors)))
+    current = graphs[0]
+
+    # Checks the author of an haiku and a
+    for (index, haiku) in enumerate(haikus):
+      author = haiku[2]
+      current[authors.index(author)] += 1
+      graphs[index] = np.copy(current)
+
+    fig = Figure(figsize=(10,  10), dpi=100)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_xlim(-1, len(haikus) * 1.05)
+    ax.set_ylim(-1, np.amax(graphs) * 1.1)
+    for (index, author) in enumerate(authors):
+      plot_author(ax, graphs[:, index], author, anonymous)
+
+    ax.legend()
+
+    faux_file = BytesIO()
+    fig.savefig(faux_file, format="PNG")
+    
+    faux_file.seek(0)
+
+    return faux_file


### PR DESCRIPTION
This introduces a new feature in haikubot, showing a number of haikus over a timeline.
Command: `@haikubot stats timeline <sprint> <anonymous>`

![image](https://user-images.githubusercontent.com/43905215/87179367-eb093980-c2de-11ea-9aa0-3489607ca6ec.png)

```
what is a request
with no haiku appended
just inadequate
```